### PR TITLE
Fixed external Fira Sans link to Carrois site

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Fira System Font Replacement
 
 These fonts are intended as a system font replacement on Mac OS X 10.11 El Capitan. If you are looking for a Fira Sans for Mac OS X 10.10 Yosemite, please use [the old release 4.100.](https://github.com/jenskutilek/FiraSystemFontReplacement/releases/tag/v4.100)
 
-The fonts are based on version 4.106 of the [Fira Sans font family](http://www.carrois.com/fira-4-1/) by Erik Spiekermann and Ralph du Carrois, and are licensed under the Open Font License version 1.1 or later. This package has been prepared by Jens Kutilek <https://github.com/jenskutilek/FiraSystemFontReplacement>.
+The fonts are based on version 4.106 of the [Fira Sans font family](https://carrois.com/typefaces/FiraSans/) by Erik Spiekermann and Ralph du Carrois, and are licensed under the Open Font License version 1.1 or later. This package has been prepared by Jens Kutilek <https://github.com/jenskutilek/FiraSystemFontReplacement>.
 
 ![](el-capitan-fira.png)
 


### PR DESCRIPTION
Correct link (updated):
https://carrois.com/typefaces/FiraSans/

Old link (broken):
https://carrois.com/fira-4-1/